### PR TITLE
Nit comment in getY

### DIFF
--- a/keeper/stableswap/math.go
+++ b/keeper/stableswap/math.go
@@ -126,6 +126,7 @@ func calculateAdjustedBalancesInRates(rates sdk.Coins, balances sdk.Coins) (sdk.
 // in the pool after the swap.
 func getY(x sdk.Coin, amp, D math.LegacyDec) (math.LegacyDec, error) {
 	// The number of tokens in the pool.
+	// Swap only supports 2 pools thus nToken is always 2.
 	nTokens := math.LegacyNewDec(2)
 
 	// amp = A * n ^ (n - 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated internal explanations to clarify that swap operations are limited to two pools. This change is solely for improving internal clarity and does not affect the functionality or performance of the application. End-users will continue to experience consistent behavior, and all visible features remain unchanged. This update enhances overall code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->