### PR TITLE
tests: check path is not conservative

### DIFF
--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -172,7 +172,7 @@ func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
 			})
 			require.Nil(t, err)
 
-			// Bob receives more funds to cover swap fees.
+			// ARRANGE: Bob receives more funds to cover swap fees.
 			bank.Balances[alice.Address] = append(bank.Balances[alice.Address], usdcLiquidity)
 			bank.Balances[alice.Address] = append(bank.Balances[alice.Address], usdnLiquidity)
 			bank.Balances[bob.Address] = append(bank.Balances[bob.Address], usdcLiquidity.AddAmount(math.NewInt(1_000)))

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -144,7 +144,6 @@ func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
-			// ARRANGE
 			account := mocks.AccountKeeper{
 				Accounts: make(map[string]sdk.AccountI),
 			}

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -110,7 +110,7 @@ func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
 			swapInAmt: math.NewInt(100),
 			initialA:  800,
 			setup: func(ctx context.Context, servers Servers) {
-				// Unbalance the pool towards uusdn
+				// Unbalance the pool towards uusdn.
 				_, err := servers.swap.Swap(ctx, &types.MsgSwap{
 					Signer: bob.Address,
 					Amount: sdk.NewCoin("uusdc", usdcLiquidity.Amount.SubRaw(101)),

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -46,8 +46,8 @@ import (
 const ONE = int64(1e6)
 
 func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
-	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(int64(1_000_000*ONE)))
-	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(int64(1_000_000*ONE)))
+	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(1_000_000*ONE))
+	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(1_000_000*ONE))
 
 	routeToUsdn := []types.Route{
 		{

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -238,8 +238,8 @@ func TestLowAmountSwapBalancedPool(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Add to pool the balance we have on mainnet
-	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(int64(1_000_000*ONE)))
-	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(int64(1_000_000*ONE)))
+	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(1_000_000*ONE))
+	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(1_000_000*ONE))
 
 	// Add funds to user balances (doesn't matter how much)
 	bank.Balances[alice.Address] = append(bank.Balances[alice.Address], usdcLiquidity)

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -21,6 +21,7 @@
 package keeper_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -43,6 +44,168 @@ import (
 )
 
 const ONE = int64(1e6)
+
+func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
+	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(int64(1_000_000*ONE)))
+	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(int64(1_000_000*ONE)))
+
+	routeToUsdn := []types.Route{
+		{
+			PoolId:  0,
+			DenomTo: "uusdn",
+		},
+	}
+
+	routeToUsdc := []types.Route{
+		{
+			PoolId:  0,
+			DenomTo: "uusdc",
+		},
+	}
+
+	alice, bob := utils.TestAccount(), utils.TestAccount()
+
+	type Servers struct {
+		swap       types.MsgServer
+		stableSwap stableswap.MsgServer
+	}
+
+	testCases := []struct {
+		name      string
+		initialA  int64
+		swapInAmt math.Int
+		// setup runs before executing the swap to unbalance the pool which will be rebalanced
+		// via the swaps function below.
+		// This is used to pre-unbalance the pool allowing to tests small amount rebalance swaps
+		// in a short amount of time.
+		setup func(context.Context, Servers)
+		// swaps accepts the context, the total amount that has to be swapped in the function, and
+		// returns the total output from swaps performed: amount out + fees
+		swaps func(context.Context, Servers, math.Int) math.Int
+	}{
+		{
+			name:      "single rebalance",
+			swapInAmt: usdcLiquidity.Amount.SubRaw(1),
+			initialA:  800,
+			setup:     func(_ context.Context, _ Servers) {},
+			swaps: func(ctx context.Context, servers Servers, totIn math.Int) math.Int {
+				resp, err := servers.swap.Swap(ctx, &types.MsgSwap{
+					Signer: bob.Address,
+					Amount: sdk.NewCoin("uusdn", totIn),
+					Routes: routeToUsdc,
+					Min:    sdk.NewCoin("uusdc", math.NewInt(0)),
+				})
+				require.Nil(t, err)
+
+				fees := math.ZeroInt()
+				if resp.Swaps[0].Fees != nil {
+					fees = resp.Swaps[0].Fees[0].Amount
+				}
+
+				return fees.Add(resp.Swaps[0].Out.Amount)
+			},
+		},
+		{
+			name:      "multiple rebalances swaps of 1uusdn",
+			swapInAmt: math.NewInt(100),
+			initialA:  800,
+			setup: func(ctx context.Context, servers Servers) {
+				// Unbalance the pool towards uusdn
+				_, err := servers.swap.Swap(ctx, &types.MsgSwap{
+					Signer: bob.Address,
+					Amount: sdk.NewCoin("uusdc", usdcLiquidity.Amount.SubRaw(101)),
+					Routes: routeToUsdn,
+					Min:    sdk.NewCoin("uusdn", math.NewInt(0)),
+				})
+				require.Nil(t, err)
+			},
+			swaps: func(ctx context.Context, servers Servers, totIn math.Int) math.Int {
+				totOut := math.ZeroInt()
+				for range totIn.Int64() {
+					resp, err := servers.swap.Swap(ctx, &types.MsgSwap{
+						Signer: bob.Address,
+						Amount: sdk.NewCoin("uusdn", math.NewInt(1)),
+						Routes: routeToUsdc,
+						Min:    sdk.NewCoin("uusdc", math.NewInt(0)),
+					})
+					require.Nil(t, err)
+
+					fees := math.ZeroInt()
+					if len(resp.Swaps[0].Fees) != 0 {
+						fees = resp.Swaps[0].Fees[0].Amount
+					}
+					totOut = totOut.Add(fees.Add(resp.Swaps[0].Out.Amount))
+				}
+
+				return totOut
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			// ARRANGE
+			account := mocks.AccountKeeper{
+				Accounts: make(map[string]sdk.AccountI),
+			}
+			bank := mocks.BankKeeper{
+				Balances:    make(map[string]sdk.Coins),
+				Restriction: mocks.NoOpSendRestrictionFn,
+			}
+			k, ctx := mocks.SwapKeeperWithKeepers(t, account, bank)
+			server := keeper.NewMsgServer(k)
+			stableswapServer := keeper.NewStableSwapMsgServer(k)
+
+			// ARRANGE: Create the Pool.
+			_, err := stableswapServer.CreatePool(ctx, &stableswap.MsgCreatePool{
+				Signer:                "authority",
+				Pair:                  "uusdc",
+				RewardsFee:            10_000_000,
+				ProtocolFeePercentage: 100,
+				InitialA:              tC.initialA,
+				FutureA:               tC.initialA,
+				FutureATime:           0,
+				RateMultipliers: sdk.NewCoins(
+					sdk.NewCoin("uusdn", math.NewInt(1_000_000_000_000_000_000)),
+					sdk.NewCoin("uusdc", math.NewInt(1_000_000_000_000_000_000)),
+				),
+			})
+			require.Nil(t, err)
+
+			// Bob receives more funds to cover swap fees.
+			bank.Balances[alice.Address] = append(bank.Balances[alice.Address], usdcLiquidity)
+			bank.Balances[alice.Address] = append(bank.Balances[alice.Address], usdnLiquidity)
+			bank.Balances[bob.Address] = append(bank.Balances[bob.Address], usdcLiquidity.AddAmount(math.NewInt(1_000)))
+			bank.Balances[bob.Address] = append(bank.Balances[bob.Address], usdnLiquidity.AddAmount(math.NewInt(1_000)))
+
+			_, err = stableswapServer.AddLiquidity(ctx, &stableswap.MsgAddLiquidity{
+				Signer: alice.Address,
+				PoolId: 0,
+				Amount: sdk.NewCoins(usdcLiquidity, usdnLiquidity),
+			})
+			assert.NoError(t, err)
+
+			servers := Servers{
+				swap:       server,
+				stableSwap: stableswapServer,
+			}
+
+			tC.setup(ctx, servers)
+
+			// Unbalance the pool towards uusdn
+			resp, err := server.Swap(ctx, &types.MsgSwap{
+				Signer: bob.Address,
+				Amount: sdk.NewCoin("uusdc", tC.swapInAmt),
+				Routes: routeToUsdn,
+				Min:    sdk.NewCoin("uusdn", math.NewInt(0)),
+			})
+			require.Nil(t, err)
+
+			totOut := tC.swaps(ctx, servers, resp.Swaps[0].Out.Amount)
+			require.GreaterOrEqual(t, tC.swapInAmt.Int64(), totOut.Int64(), "expected unbalance and rebalance to be not profitable")
+		})
+	}
+}
 
 func TestLowAmountSwapBalancedPool(t *testing.T) {
 	account := mocks.AccountKeeper{
@@ -75,8 +238,8 @@ func TestLowAmountSwapBalancedPool(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Add to pool the balance we have on mainnet
-	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(int64(1_000_000_000_000)))
-	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(int64(1_000_000_000_000)))
+	usdnLiquidity := sdk.NewCoin("uusdn", math.NewInt(int64(1_000_000*ONE)))
+	usdcLiquidity := sdk.NewCoin("uusdc", math.NewInt(int64(1_000_000*ONE)))
 
 	// Add funds to user balances (doesn't matter how much)
 	bank.Balances[alice.Address] = append(bank.Balances[alice.Address], usdcLiquidity)
@@ -301,12 +464,12 @@ func TestConformance(t *testing.T) {
 				Min:    sdk.NewCoin("uusdc", math.NewInt(ONE)),
 			},
 			types.MsgSwapResponse{
-				Result: sdk.NewCoin("uusdc", math.NewInt(99971838)),
+				Result: sdk.NewCoin("uusdc", math.NewInt(99972764)),
 				Swaps: []*types.Swap{
 					{
 						PoolId: 0,
 						In:     sdk.NewCoin("uusdn", math.NewInt(100*ONE)),
-						Out:    sdk.NewCoin("uusdc", math.NewInt(99971838)),
+						Out:    sdk.NewCoin("uusdc", math.NewInt(99972764)),
 						Fees:   sdk.NewCoins(sdk.NewCoin("uusdn", math.NewInt(24998))),
 					},
 				},
@@ -1582,7 +1745,7 @@ func TestSwap(t *testing.T) {
 	})
 	// ACT: Expect a successful swap and validate all the resulting amounts.
 	assert.Nil(t, err)
-	assert.Equal(t, response.Result, sdk.NewCoin("uusdn", math.NewInt(99999958)))
+	assert.Equal(t, sdk.NewCoin("uusdn", math.NewInt(99999959)), response.Result)
 	pool, _ := k.Pools.Get(ctx, 0)
 	assert.Equal(t, bank.Balances[pool.Address].AmountOf("uusdc"), math.NewInt(nLiquidity.Amount.Int64()+(100*ONE)-response.Swaps[0].Fees.AmountOf("uusdc").Int64()))
 	assert.Equal(t, bank.Balances[pool.Address].AmountOf("uusdn"), math.NewInt(usdcLiquidity.Amount.Int64()-response.Result.Amount.Int64()))
@@ -1613,69 +1776,6 @@ func TestSwap(t *testing.T) {
 		Min:    sdk.NewCoin("uusdn", math.NewInt(99990000)),
 	})
 	assert.NoError(t, err)
-}
-
-func TestNegativeSwapResult(t *testing.T) {
-	bob := utils.TestAccount()
-	account := mocks.AccountKeeper{
-		Accounts: make(map[string]sdk.AccountI),
-	}
-	bank := mocks.BankKeeper{
-		Balances:    make(map[string]sdk.Coins),
-		Restriction: mocks.NoOpSendRestrictionFn,
-	}
-	bank.Balances[bob.Address] = append(bank.Balances[bob.Address], sdk.NewCoin("uusdc", math.NewInt(10000*ONE)))
-	bank.Balances[bob.Address] = append(bank.Balances[bob.Address], sdk.NewCoin("uusdn", math.NewInt(10000*ONE)))
-	k, ctx := mocks.SwapKeeperWithKeepers(t, account, bank)
-	server := keeper.NewMsgServer(k)
-	stableswapServer := keeper.NewStableSwapMsgServer(k)
-
-	// ARRANGE: Create a Pool.
-	_, err := stableswapServer.CreatePool(ctx, &stableswap.MsgCreatePool{
-		Signer:                "authority",
-		Pair:                  "uusdc",
-		ProtocolFeePercentage: 50,
-		RewardsFee:            2_500_000,
-		InitialA:              1000,
-		FutureA:               1000,
-		FutureATime:           0,
-		RateMultipliers: sdk.NewCoins(
-			sdk.NewCoin("uusdn", math.NewInt(1e18)),
-			sdk.NewCoin("uusdc", math.NewInt(1e18)),
-		),
-	})
-	require.NoError(t, err)
-
-	// ARRANGE: Create a liquidity position for bob.
-	_, err = stableswapServer.AddLiquidity(ctx, &stableswap.MsgAddLiquidity{
-		Signer: bob.Address,
-		PoolId: 0,
-		Amount: sdk.NewCoins(
-			sdk.NewCoin("uusdn", math.NewInt(10*ONE)),
-			sdk.NewCoin("uusdc", math.NewInt(10*ONE)),
-		),
-	})
-	require.NoError(t, err)
-
-	// ARRANGE: make the pool unbalanced.
-	_, err = server.Swap(ctx, &types.MsgSwap{
-		Signer: bob.Address,
-		Amount: sdk.NewCoin("uusdn", math.NewInt(1000*ONE)),
-		Routes: []types.Route{{PoolId: 0, DenomTo: "uusdc"}},
-		Min:    sdk.NewCoin("uusdc", math.NewInt(ONE)),
-	})
-	require.NoError(t, err)
-
-	// ACT: perform a swap without enough liquidity.
-	_, err = server.Swap(ctx, &types.MsgSwap{
-		Signer: bob.Address,
-		Amount: sdk.NewCoin("uusdn", math.NewInt(1000)),
-		Routes: []types.Route{{PoolId: 0, DenomTo: "uusdc"}},
-		Min:    sdk.NewCoin("uusdc", math.NewInt(1)),
-	})
-	require.Error(t, err)
-	// ASSERT: expect matching error.
-	require.Equal(t, "error computing swap routes plan: not enough liquidity to complete the swap", err.Error())
 }
 
 func TestMultiPoolSwap(t *testing.T) {
@@ -1764,7 +1864,7 @@ func TestMultiPoolSwap(t *testing.T) {
 	assert.Nil(t, err)
 
 	// ASSERT: Expect matching values in state.
-	assert.Equal(t, response.Result, sdk.NewCoin("uusde", math.NewInt(99999916)))
+	assert.Equal(t, sdk.NewCoin("uusde", math.NewInt(99999918)), response.Result)
 	pool0, _ := k.Pools.Get(ctx, 0)
 	assert.Equal(t, bank.Balances[pool0.Address].AmountOf("uusdc"), math.NewInt(nLiquidity.Amount.Int64()+(100*ONE)-response.Swaps[0].Fees.AmountOf("uusdc").Int64()))
 	assert.Equal(t, bank.Balances[pool0.Address].AmountOf("uusdn"), math.NewInt(usdcLiquidity.Amount.Int64()-response.Swaps[0].Out.Amount.Int64()))

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -192,7 +192,7 @@ func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
 
 			tC.setup(ctx, servers)
 
-			// Unbalance the pool towards uusdn
+			// ACT: Unbalance the pool towards uusdn.
 			resp, err := server.Swap(ctx, &types.MsgSwap{
 				Signer: bob.Address,
 				Amount: sdk.NewCoin("uusdc", tC.swapInAmt),

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -80,7 +80,7 @@ func TestUnbalanceAndRebalanceIsNotConservative(t *testing.T) {
 		// in a short amount of time.
 		setup func(context.Context, Servers)
 		// swaps accepts the context, the total amount that has to be swapped in the function, and
-		// returns the total output from swaps performed: amount out + fees
+		// returns the total output from swaps performed: amount out + fees.
 		swaps func(context.Context, Servers, math.Int) math.Int
 	}{
 		{

--- a/keeper/msg_stableswap_server_test.go
+++ b/keeper/msg_stableswap_server_test.go
@@ -35,6 +35,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"swap.noble.xyz/keeper"
 	stableswapkeeper "swap.noble.xyz/keeper/stableswap"
 	"swap.noble.xyz/types"

--- a/keeper/query_server_test.go
+++ b/keeper/query_server_test.go
@@ -26,6 +26,7 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
+
 	"swap.noble.xyz/keeper"
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"
@@ -112,11 +113,11 @@ func TestSimulateSwap(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, &types.MsgSwapResponse{
-		Result: sdk.NewCoin("uusdn", math.NewInt(99999998)),
+		Result: sdk.NewCoin("uusdn", math.NewInt(99999999)),
 		Swaps: []*types.Swap{
 			{
 				In:   sdk.NewCoin("uusdc", math.NewInt(100000000)),
-				Out:  sdk.NewCoin("uusdn", math.NewInt(99999998)),
+				Out:  sdk.NewCoin("uusdn", math.NewInt(99999999)),
 				Fees: sdk.Coins{},
 			},
 		},
@@ -516,7 +517,7 @@ func TestRate(t *testing.T) {
 			{
 				Denom:     "uusdc",
 				Vs:        "uusdn",
-				Price:     math.LegacyMustNewDecFromStr("0.003152000000000000"),
+				Price:     math.LegacyMustNewDecFromStr("0.002232000000000000"),
 				Algorithm: types.STABLESWAP,
 			},
 		},
@@ -544,7 +545,7 @@ func TestRate(t *testing.T) {
 			{
 				Denom:     "uusdc",
 				Vs:        "uusdn",
-				Price:     math.LegacyMustNewDecFromStr("0.003152000000000000"),
+				Price:     math.LegacyMustNewDecFromStr("0.002232000000000000"),
 				Algorithm: types.STABLESWAP,
 			},
 		},
@@ -564,7 +565,7 @@ func TestRate(t *testing.T) {
 			{
 				Denom:     "uusdc",
 				Vs:        "uusdn",
-				Price:     math.LegacyMustNewDecFromStr("0.003152000000000000"),
+				Price:     math.LegacyMustNewDecFromStr("0.002232000000000000"),
 				Algorithm: types.STABLESWAP,
 			},
 		},
@@ -693,7 +694,7 @@ func TestRates(t *testing.T) {
 			{
 				Denom:     "uusde",
 				Vs:        "uusdn",
-				Price:     math.LegacyMustNewDecFromStr("0.009899000000000000"),
+				Price:     math.LegacyMustNewDecFromStr("0.007021000000000000"),
 				Algorithm: types.STABLESWAP,
 			},
 			{
@@ -705,7 +706,7 @@ func TestRates(t *testing.T) {
 			{
 				Denom:     "uusdn",
 				Vs:        "uusde",
-				Price:     math.LegacyMustNewDecFromStr("101.020305081321345590"),
+				Price:     math.LegacyMustNewDecFromStr("142.429853297251103831"),
 				Algorithm: types.STABLESWAP,
 			},
 		},
@@ -735,7 +736,7 @@ func TestRates(t *testing.T) {
 			{
 				Denom:     "uusde",
 				Vs:        "uusdn",
-				Price:     math.LegacyMustNewDecFromStr("0.009899000000000000"),
+				Price:     math.LegacyMustNewDecFromStr("0.007021000000000000"),
 				Algorithm: types.STABLESWAP,
 			},
 			{
@@ -747,7 +748,7 @@ func TestRates(t *testing.T) {
 			{
 				Denom:     "uusdn",
 				Vs:        "uusde",
-				Price:     math.LegacyMustNewDecFromStr("101.020305081321345590"),
+				Price:     math.LegacyMustNewDecFromStr("142.429853297251103831"),
 				Algorithm: types.STABLESWAP,
 			},
 		},
@@ -770,7 +771,7 @@ func TestRates(t *testing.T) {
 			{
 				Denom:     "uusde",
 				Vs:        "uusdn",
-				Price:     math.LegacyMustNewDecFromStr("0.009899000000000000"),
+				Price:     math.LegacyMustNewDecFromStr("0.007021000000000000"),
 				Algorithm: types.STABLESWAP,
 			},
 			{
@@ -782,7 +783,7 @@ func TestRates(t *testing.T) {
 			{
 				Denom:     "uusdn",
 				Vs:        "uusde",
-				Price:     math.LegacyMustNewDecFromStr("101.020305081321345590"),
+				Price:     math.LegacyMustNewDecFromStr("142.429853297251103831"),
 				Algorithm: types.STABLESWAP,
 			},
 		},

--- a/keeper/stableswap/controller.go
+++ b/keeper/stableswap/controller.go
@@ -32,6 +32,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	anyproto "github.com/cosmos/gogoproto/types/any"
+
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"
 	stableswaptypes "swap.noble.xyz/types/stableswap"
@@ -381,7 +382,7 @@ func (c *Controller) GetRates(ctx context.Context) []types.Rate {
 	basePrice := c.GetRate(ctx)
 
 	// If the base price is greater than zero, compute the inverse price.
-	if basePrice.GT(math.LegacyZeroDec()) {
+	if basePrice.IsPositive() {
 		price = basePrice
 		vsPrice = math.LegacyOneDec().Quo(basePrice)
 	}


### PR DESCRIPTION
Unbalancing the pool and rebalancing with the same amount should be a positive sum path for the pool. This PR add a test cases to check this behavior is respected and fix a couple of broken tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded liquidity pool swap testing to cover both unbalanced and rebalanced scenarios, ensuring that swap outputs remain consistent and reliable.
  - Updated expected results for various swap assertions to reflect new calculations.

- **Bug Fixes**
  - Adjusted conversion rates and swap outcome values for improved accuracy.
  - Removed an outdated scenario to better reflect proper swap behavior.

- **Refactor**
  - Simplified the logic for validating rate calculations, streamlining the overall swap process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->