### PR TITLE
chore: improve formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build:
 ###                          Formatting & Linting                           ###
 ###############################################################################
 
+goimports_reviser=github.com/incu6us/goimports-reviser/v3
 gofumpt_cmd=mvdan.cc/gofumpt
 golangci_lint_cmd=github.com/golangci/golangci-lint/cmd/golangci-lint
 
@@ -23,6 +24,7 @@ license:
 
 format:
 	@echo "🤖 Running formatter..."
+	@go run $(goimports_reviser) -company-prefixes "github.com/cosmos,cosmossdk.io,github.com/cometbft,github.com/grpc-ecosystem" -excludes 'utils/tools.go' -rm-unused -set-alias ./...
 	@go run $(gofumpt_cmd) -l -w .
 	@echo "✅ Completed formatting!"
 

--- a/genesis.go
+++ b/genesis.go
@@ -23,11 +23,11 @@ package swap
 import (
 	"context"
 
-	stableswaptypes "swap.noble.xyz/types/stableswap"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"swap.noble.xyz/keeper"
 	"swap.noble.xyz/types"
+	stableswaptypes "swap.noble.xyz/types/stableswap"
 )
 
 func InitGenesis(ctx context.Context, k *keeper.Keeper, gen types.GenesisState) {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/golangci/golangci-lint v1.61.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/incu6us/goimports-reviser/v3 v3.8.2
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed
 	google.golang.org/grpc v1.67.1

--- a/go.sum
+++ b/go.sum
@@ -575,6 +575,8 @@ github.com/improbable-eng/grpc-web v0.15.0/go.mod h1:1sy9HKV4Jt9aEs9JSnkWlRJPuPt
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/incu6us/goimports-reviser/v3 v3.8.2 h1:OYs6hqJ3oaAR0X7jMszIM/tcxMw2l/gkB2C/VGcItdE=
+github.com/incu6us/goimports-reviser/v3 v3.8.2/go.mod h1:r0jYpyePwPYiqxl4qjZ0xZgVEPKS/ePqVCT3XNuwR54=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jgautheron/goconst v1.7.1 h1:VpdAG7Ca7yvvJk5n8dMwQhfEZJh95kl/Hl9S1OI5Jkk=
 github.com/jgautheron/goconst v1.7.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=

--- a/go.work.sum
+++ b/go.work.sum
@@ -640,7 +640,6 @@ github.com/gonum/internal v0.0.0-20181124074243-f884aa714029/go.mod h1:Pu4dmpkhS
 github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9/go.mod h1:XA3DeT6rxh2EAE789SSiSJNqxPaC0aE9J8NTOI0Jo/A=
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/generative-ai-go v0.17.0 h1:kUmCXUIwJouD7I7ev3OmxzzQVICyhIWAxaXk2yblCMY=
 github.com/google/generative-ai-go v0.17.0/go.mod h1:JYolL13VG7j79kM5BtHz4qwONHkeJQzOCkKXnpqtS/E=
@@ -752,6 +751,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
+github.com/incu6us/goimports-reviser/v3 v3.8.2/go.mod h1:r0jYpyePwPYiqxl4qjZ0xZgVEPKS/ePqVCT3XNuwR54=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab h1:HqW4xhhynfjrtEiiSGcQUd6vrK23iMam1FO8rI7mwig=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/informalsystems/tm-load-test v1.3.0 h1:FGjKy7vBw6mXNakt+wmNWKggQZRsKkEYpaFk/zR64VA=

--- a/keeper/abci_stableswap_test.go
+++ b/keeper/abci_stableswap_test.go
@@ -24,11 +24,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/header"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"
 	"swap.noble.xyz/utils"

--- a/keeper/abci_test.go
+++ b/keeper/abci_test.go
@@ -23,8 +23,10 @@ package keeper_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"swap.noble.xyz/types/stableswap"
 	"swap.noble.xyz/utils/mocks"
 )

--- a/keeper/controller.go
+++ b/keeper/controller.go
@@ -28,6 +28,7 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	anyproto "github.com/cosmos/gogoproto/types/any"
+
 	"swap.noble.xyz/types"
 )
 

--- a/keeper/controller_stableswap.go
+++ b/keeper/controller_stableswap.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	sdkerrors "cosmossdk.io/errors"
+
 	"swap.noble.xyz/keeper/stableswap"
 	"swap.noble.xyz/types"
 )

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -33,6 +33,7 @@ import (
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	modulev1 "swap.noble.xyz/api/module/v1"
 	"swap.noble.xyz/keeper/stableswap"
 	"swap.noble.xyz/types"

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -23,10 +23,12 @@ package keeper_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/stretchr/testify/require"
+
 	modulev1 "swap.noble.xyz/api/module/v1"
 	"swap.noble.xyz/keeper"
 	"swap.noble.xyz/types"

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -24,9 +24,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gogo/protobuf/sortkeys"
+
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/gogo/protobuf/sortkeys"
+
 	"swap.noble.xyz/types"
 )
 

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -25,14 +25,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/header"
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"swap.noble.xyz/keeper"
 	stableswapkeeper "swap.noble.xyz/keeper/stableswap"

--- a/keeper/msg_stableswap_server.go
+++ b/keeper/msg_stableswap_server.go
@@ -27,6 +27,7 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	swapv1 "swap.noble.xyz/api/v1"
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"

--- a/keeper/msg_stableswap_server_test.go
+++ b/keeper/msg_stableswap_server_test.go
@@ -22,9 +22,12 @@ package keeper_test
 
 import (
 	"fmt"
-	"math/rand/v2"
+	rand "math/rand/v2"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/header"
@@ -33,8 +36,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
 	"swap.noble.xyz/keeper"
 	stableswapkeeper "swap.noble.xyz/keeper/stableswap"
 	"swap.noble.xyz/types"

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -25,10 +25,12 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/gogo/protobuf/sortkeys"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/gogo/protobuf/sortkeys"
+
 	"swap.noble.xyz/types"
 )
 

--- a/keeper/query_server_test.go
+++ b/keeper/query_server_test.go
@@ -23,9 +23,11 @@ package keeper_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+
 	"swap.noble.xyz/keeper"
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"

--- a/keeper/query_stableswap_server.go
+++ b/keeper/query_stableswap_server.go
@@ -27,6 +27,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
+
 	"swap.noble.xyz/types/stableswap"
 )
 

--- a/keeper/query_stableswap_server_test.go
+++ b/keeper/query_stableswap_server_test.go
@@ -24,10 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"cosmossdk.io/core/header"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+
 	"swap.noble.xyz/keeper"
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"

--- a/keeper/stableswap/controller.go
+++ b/keeper/stableswap/controller.go
@@ -32,6 +32,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	anyproto "github.com/cosmos/gogoproto/types/any"
+
 	"swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"
 	stableswaptypes "swap.noble.xyz/types/stableswap"

--- a/keeper/stableswap/controller_test.go
+++ b/keeper/stableswap/controller_test.go
@@ -24,12 +24,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
 	"swap.noble.xyz/keeper"
 	"swap.noble.xyz/keeper/stableswap"
 	"swap.noble.xyz/types"

--- a/keeper/stableswap/keeper.go
+++ b/keeper/stableswap/keeper.go
@@ -29,6 +29,7 @@ import (
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	swapv1 "swap.noble.xyz/api/v1"
 	"swap.noble.xyz/types"
 	stableswaptypes "swap.noble.xyz/types/stableswap"

--- a/keeper/stableswap/state.go
+++ b/keeper/stableswap/state.go
@@ -25,6 +25,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
+
 	"swap.noble.xyz/types/stableswap"
 )
 

--- a/keeper/stableswap/state_test.go
+++ b/keeper/stableswap/state_test.go
@@ -24,11 +24,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+
 	stableswapkeeper "swap.noble.xyz/keeper/stableswap"
 	types2 "swap.noble.xyz/types"
 	"swap.noble.xyz/types/stableswap"

--- a/keeper/stableswap/types.go
+++ b/keeper/stableswap/types.go
@@ -23,6 +23,7 @@ package stableswap
 import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/collections/indexes"
+
 	stableswaptypes "swap.noble.xyz/types/stableswap"
 )
 

--- a/keeper/state_test.go
+++ b/keeper/state_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"swap.noble.xyz/utils/mocks"
 )
 

--- a/module.go
+++ b/module.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+
 	modulev1 "swap.noble.xyz/api/module/v1"
 	stableswapv1 "swap.noble.xyz/api/stableswap/v1"
 	swapv1 "swap.noble.xyz/api/v1"

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -18,20 +18,20 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	_ "github.com/cosmos/cosmos-sdk/x/auth" // import for side effects
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config" // import for side effects
+	_ "github.com/cosmos/cosmos-sdk/x/bank"           // import for side effects
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	_ "github.com/cosmos/cosmos-sdk/x/consensus" // import for side effects
 	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	_ "github.com/cosmos/cosmos-sdk/x/staking" // import for side effects
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	swapkeeper "swap.noble.xyz/keeper"
 
-	_ "github.com/cosmos/cosmos-sdk/x/auth"           // import for side effects
-	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config" // import for side effects
-	_ "github.com/cosmos/cosmos-sdk/x/bank"           // import for side effects
-	_ "github.com/cosmos/cosmos-sdk/x/consensus"      // import for side effects
-	_ "github.com/cosmos/cosmos-sdk/x/staking"        // import for side effects
-	_ "swap.noble.xyz"                                // import for side effects
+	_ "swap.noble.xyz" // import for side effects
+	swapkeeper "swap.noble.xyz/keeper"
 )
 
 var DefaultNodeHome string

--- a/simapp/simd/cmd/commands.go
+++ b/simapp/simd/cmd/commands.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"io"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
-
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/debug"
@@ -22,8 +24,7 @@ import (
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
 	"swap.noble.xyz/simapp"
 )
 

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"cosmossdk.io/client/v2/autocli"
 	clientv2keyring "cosmossdk.io/client/v2/autocli/keyring"
 	"cosmossdk.io/core/address"
@@ -21,7 +23,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	txmodule "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/spf13/cobra"
+
 	"swap.noble.xyz/simapp"
 )
 

--- a/simapp/simd/main.go
+++ b/simapp/simd/main.go
@@ -6,6 +6,7 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"swap.noble.xyz/simapp"
 	"swap.noble.xyz/simapp/simd/cmd"
 )

--- a/types/codec.go
+++ b/types/codec.go
@@ -25,6 +25,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
+
 	"swap.noble.xyz/types/stableswap"
 )
 

--- a/types/types.go
+++ b/types/types.go
@@ -23,6 +23,7 @@ package types
 import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"swap.noble.xyz/types/stableswap"
 )
 

--- a/utils/mocks/account.go
+++ b/utils/mocks/account.go
@@ -26,6 +26,7 @@ import (
 	"cosmossdk.io/core/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/codec"
+
 	"swap.noble.xyz/types"
 )
 

--- a/utils/mocks/bank.go
+++ b/utils/mocks/bank.go
@@ -28,6 +28,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	"swap.noble.xyz/types"
 )
 

--- a/utils/mocks/swap.go
+++ b/utils/mocks/swap.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+
 	swap "swap.noble.xyz"
 	modulev1 "swap.noble.xyz/api/module/v1"
 	"swap.noble.xyz/keeper"

--- a/utils/tools.go
+++ b/utils/tools.go
@@ -27,5 +27,6 @@ package tools
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/incu6us/goimports-reviser/v3"
 	_ "mvdan.cc/gofumpt"
 )


### PR DESCRIPTION
Add `goimport-reviser` for better formatting of imported packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Integrated a new tool to enhance Go import formatting and management.
  - Added a new dependency to support improved code formatting.
- **Style**
  - Reorganized and cleaned up import statements across multiple files for better readability and consistency.
  - Removed duplicate imports and improved grouping of related packages.
- **New Features**
  - Expanded codebase with additional package imports, enabling access to new types and functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->